### PR TITLE
Enhance current API display

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -135,12 +135,12 @@ export function App() {
       // if the chatStore is not found, we need to override the endpoint
       // with the default one
       toast({
-        title: "New chat session created",
+        title: "New chat created",
         description: `API Endpoint: ${ret.apiEndpoint}`,
       });
     } else {
       toast({
-        title: "Chat history loaded",
+        title: "Chat ready",
         description: `Current API Endpoint: ${ret.apiEndpoint}`,
       });
     }
@@ -157,7 +157,7 @@ export function App() {
     setSelectedChatIndex(newKey as number);
     setAllChatStoreIndexes(await (await db).getAllKeys(STORAGE_NAME));
     toast({
-      title: "New chat session created",
+      title: "New chat created",
       description: `Current API Endpoint: ${chatStore.apiEndpoint}`,
     });
   };

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -110,11 +110,14 @@ export function App() {
   const { toast } = useToast();
 
   const getChatStoreByIndex = async (index: number): Promise<ChatStore> => {
-    let isOverrideEndpoint = false;
     const ret: ChatStore = await (await db).get(STORAGE_NAME, index);
     if (ret === null || ret === undefined) {
-      isOverrideEndpoint = true;
-      return newChatStore({});
+      const newStore = newChatStore({});
+      toast({
+        title: "New chat created",
+        description: `Current API Endpoint: ${newStore.apiEndpoint}`,
+      });
+      return newStore;
     }
     // handle read from old version chatstore
     if (ret.maxGenTokens === undefined) ret.maxGenTokens = 2048;
@@ -131,19 +134,11 @@ export function App() {
         message.token = calculate_token_length(message.content);
     }
     if (ret.cost === undefined) ret.cost = 0;
-    if (isOverrideEndpoint) {
-      // if the chatStore is not found, we need to override the endpoint
-      // with the default one
-      toast({
-        title: "New chat created",
-        description: `API Endpoint: ${ret.apiEndpoint}`,
-      });
-    } else {
-      toast({
-        title: "Chat ready",
-        description: `Current API Endpoint: ${ret.apiEndpoint}`,
-      });
-    }
+
+    toast({
+      title: "Chat ready",
+      description: `Current API Endpoint: ${ret.apiEndpoint}`,
+    });
     return ret;
   };
 

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -90,7 +90,6 @@ import { useToast } from "@/hooks/use-toast";
 import { ModeToggle } from "@/components/ModeToggle";
 
 import Navbar from "@/components/navbar";
-import { is } from "date-fns/locale";
 
 export function App() {
   // init selected index


### PR DESCRIPTION
As noted in #12, the current active API Endpoint can be unclear, particularly when there is a endpoint change when requests with GET parameters.

This update introduces a UI toast notification whenever a ChatStore is switched (either newly created or retrieved from the database). The toast displays the current API endpoint, helping users quickly identify the active API in use. This enhancement aims to reduce confusion and improve clarity around which API the user is interacting with.

## Screenshot

1. Load history ChatStore (click any existing chat session or refresh)
<img width="403" alt="image" src="https://github.com/user-attachments/assets/400f236f-9f54-42c3-a056-0fd9e2c9a77a" />


2. When URL with endpoint parameter
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/0687b66e-bfa9-474b-808f-d66e4646b40c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user feedback for chat store creation.
	- Improved toast notifications displaying API endpoint details.

- **Bug Fixes**
	- Refined chat creation messaging to provide clearer context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->